### PR TITLE
explicitly call the setup() method on the parent class of our api test case.

### DIFF
--- a/tests/api_test.php
+++ b/tests/api_test.php
@@ -54,6 +54,7 @@ final class api_test extends externallib_advanced_testcase {
      * {@inheritDoc}
      */
     protected function setUp(): void {
+        parent::setUp();
         $this->resetAfterTest();
     }
 


### PR DESCRIPTION
we're getting dinged for not doing so by the codesniffer in a Moodle 4.5 context, see moodlehq/moodle-cs issue 106 for details.

for reference, see this failed task run https://github.com/ucsf-education/tool_ucsfsomapi/actions/runs/13641512333/job/38132246673?pr=24